### PR TITLE
No RGBA

### DIFF
--- a/render/svg.go
+++ b/render/svg.go
@@ -49,6 +49,7 @@ func BoxSVG(q UIBox) string {
 	r = r >> 8
 	g = g >> 8
 	b = b >> 8
+	o := float64(a>>8) / 255.0
 
 	br, bg, bb, ba := color.White.RGBA()
 	if q.BorderColor != color.Opaque {
@@ -57,6 +58,7 @@ func BoxSVG(q UIBox) string {
 	br = br >> 8
 	bg = bg >> 8
 	bb = bb >> 8
+	bo := float64(ba>>8) / 255.0
 
 	return fmt.Sprintf(`
 <g>
@@ -68,7 +70,7 @@ func BoxSVG(q UIBox) string {
 		q.Y,
 		q.W,
 		q.H,
-		fmt.Sprintf("fill: rgba(%d, %d, %d, %d);opacity:1;fill-opacity:1;stroke:rgba(%d,%d,%d,%d);stroke-width:1px;stroke-opacity:1;", r, g, b, a, br, bg, bb, ba),
+		fmt.Sprintf("fill: rgb(%d, %d, %d);opacity:1;fill-opacity:%.2f;stroke:rgb(%d,%d,%d);stroke-width:1px;stroke-opacity:%.2f;", r, g, b, o, br, bg, bb, bo),
 		TextSVG(q.Title),
 	)
 }
@@ -86,6 +88,7 @@ func TextSVG(t *UIText) string {
 	r = r >> 8
 	g = g >> 8
 	b = b >> 8
+	o := float64(a>>8) / 255.0
 
 	s := fmt.Sprintf(`
 <text 
@@ -98,7 +101,7 @@ func TextSVG(t *UIText) string {
 		t.X,
 		t.Y+t.H,
 		t.Scale,
-		fmt.Sprintf("font-family: Open Sans, verdana, arial, sans-serif !important; font-size: %dpx; fill: rgb(%d, %d, %d, %d); fill-opacity: 1; white-space: pre;", fontSize, r, g, b, a),
+		fmt.Sprintf("font-family: Open Sans, verdana, arial, sans-serif !important; font-size: %dpx; fill: rgb(%d, %d, %d); fill-opacity: %.2f; white-space: pre;", fontSize, r, g, b, o),
 		t.Text,
 	)
 	return s


### PR DESCRIPTION
This PR changes SVG generation to use `rbg(...)` instead of `rgba(...)`, which is not supported by Inkscape.

Alpha is scaled to range [0, 1] and used in the `...-opacity` properties.

Alpha can't currently appear when used via the CLI, as it is not supported by the `colorful.Hex()` function that is used for palettes. Decided to still leave alpha in for use as a library.

Not 100% sure about the bitshift, but it looks like alpha is treated the same as color channels.

Fixes #21 

Screenshot Inkscape before:

![grafik](https://user-images.githubusercontent.com/44003176/208129418-d8c64c74-4884-4df3-b98e-0d00d36ee7cb.png)

After:

![grafik](https://user-images.githubusercontent.com/44003176/208129517-6b328171-e158-4f53-a564-751f34a83786.png)

Screen to verify that using `fill-opacity` and leaving `opacity` at 1 works:

![grafik](https://user-images.githubusercontent.com/44003176/208130059-cbcb0117-7afb-4130-ba92-fc736a607d18.png)
