### PR TITLE
Escale illegal XML characters

### DIFF
--- a/parser/csv_tree_parser.go
+++ b/parser/csv_tree_parser.go
@@ -34,6 +34,7 @@ func (s CSVTreeParser) ParseString(in string) (*treemap.Tree, error) {
 func parseNodes(in string) ([]treemap.Node, error) {
 	var nodes []treemap.Node
 	r := csv.NewReader(strings.NewReader(in))
+	r.LazyQuotes = true
 	for {
 		record, err := r.Read()
 		if err == io.EOF {

--- a/parser/csv_tree_parser_test.go
+++ b/parser/csv_tree_parser_test.go
@@ -176,6 +176,18 @@ func TestParseNodes(t *testing.T) {
 			},
 		},
 		{
+			name: "when quotation, then works",
+			in:   "a\"b\",1,1",
+			expNodes: []treemap.Node{
+				{
+					Path:    "a\"b\"",
+					Size:    1,
+					Heat:    1,
+					HasHeat: true,
+				},
+			},
+		},
+		{
 			name:   "when wrong number, then error",
 			in:     ",,\n\n",
 			expErr: "is not float",
@@ -184,11 +196,6 @@ func TestParseNodes(t *testing.T) {
 			name:   "when wrong number, then error",
 			in:     ",1,\n\n",
 			expErr: "is not float",
-		},
-		{
-			name:   "when wrong quotation, then error",
-			in:     "\"\n\n",
-			expErr: "can not parse",
 		},
 	}
 	for _, tc := range tests {

--- a/parser/csv_tree_parser_test.go
+++ b/parser/csv_tree_parser_test.go
@@ -188,6 +188,18 @@ func TestParseNodes(t *testing.T) {
 			},
 		},
 		{
+			name: "when quoted field, then no quotes",
+			in:   "\"ab\",1,1",
+			expNodes: []treemap.Node{
+				{
+					Path:    "ab",
+					Size:    1,
+					Heat:    1,
+					HasHeat: true,
+				},
+			},
+		},
+		{
 			name:   "when wrong number, then error",
 			in:     ",,\n\n",
 			expErr: "is not float",

--- a/render/svg.go
+++ b/render/svg.go
@@ -3,6 +3,15 @@ package render
 import (
 	"fmt"
 	"image/color"
+	"strings"
+)
+
+var xmlEscaper = strings.NewReplacer(
+	"&", "&amp;",
+	"<", "&lt;",
+	">", "&gt;",
+	"\"", "&quot;",
+	"'", "&apos;",
 )
 
 type SVGRenderer struct{}
@@ -102,7 +111,7 @@ func TextSVG(t *UIText) string {
 		t.Y+t.H,
 		t.Scale,
 		fmt.Sprintf("font-family: Open Sans, verdana, arial, sans-serif !important; font-size: %dpx; fill: rgb(%d, %d, %d); fill-opacity: %.2f; white-space: pre;", fontSize, r, g, b, o),
-		t.Text,
+		xmlEscaper.Replace(t.Text),
 	)
 	return s
 }

--- a/testdata/escape-xml-chars-path.csv
+++ b/testdata/escape-xml-chars-path.csv
@@ -1,0 +1,5 @@
+root/A & B
+root/A < B
+root/A > B
+root/"dbl-quoted"
+root/'quoted'


### PR DESCRIPTION
Escapes illegal XML characters.

Decided to do it in `svg.go` rather than in the `UIText` construction, as the issue is specific for SVG rendering.

Not sure how to add useful unit tests for this.

Fixes #20 