### PR TITLE
Slashes through entities

### DIFF
--- a/collapse_long_paths.go
+++ b/collapse_long_paths.go
@@ -24,7 +24,7 @@ func CollapseLongPathsFromNode(t *Tree, nodeName string) {
 	for children := t.To[q]; len(children) == 1; children = t.To[q] {
 		nextChild := children[0]
 
-		parts = append(parts, t.Nodes[q].Name)
+		parts = append(parts, slashToEntity.Replace(t.Nodes[q].Name))
 		delete(t.Nodes, q)
 		delete(t.To, q)
 
@@ -40,7 +40,7 @@ func CollapseLongPathsFromNode(t *Tree, nodeName string) {
 		node := t.Nodes[q]
 
 		// add last child node name to path
-		parts = append(parts, node.Name)
+		parts = append(parts, slashToEntity.Replace(node.Name))
 
 		// copy fields from child to current node
 		t.Nodes[nodeName] = Node{

--- a/size_imputer.go
+++ b/size_imputer.go
@@ -26,7 +26,7 @@ func (s SumSizeImputer) ImputeSizeNode(t Tree, node string) {
 
 		var name string
 		if parts := strings.Split(node, "/"); len(parts) > 0 {
-			name = parts[len(parts)-1]
+			name = entityToSlash.Replace(parts[len(parts)-1])
 		}
 
 		t.Nodes[node] = Node{

--- a/treemap.go
+++ b/treemap.go
@@ -5,6 +5,14 @@ import "strings"
 // for numerical stability
 const minHeatDifferenceForHeatmap float64 = 0.0000001
 
+var entityToSlash = strings.NewReplacer(
+	"&sol;", "/",
+)
+
+var slashToEntity = strings.NewReplacer(
+	"/", "&sol;",
+)
+
 type Node struct {
 	Path    string
 	Name    string
@@ -85,7 +93,7 @@ func SetNamesFromPaths(t *Tree) {
 
 		t.Nodes[path] = Node{
 			Path:    node.Path,
-			Name:    parts[len(parts)-1],
+			Name:    entityToSlash.Replace(parts[len(parts)-1]),
 			Size:    node.Size,
 			Heat:    node.Heat,
 			HasHeat: node.HasHeat,


### PR DESCRIPTION
A suggestion to solve #25.

Names can show up with slashes by the use of the `&sol;` HTML entity.

Internally, the entity is replaced by slash when assigning names, and the contrary when constructing paths from names.
String length calculations are performed on names (not paths), so they don't encounter the (potentially compromising) entity.

**TODO**

* [x] Add tests

Screenshot showing it in action:

![test](https://user-images.githubusercontent.com/44003176/208487353-2f2a74b5-f556-4ea1-a5d0-913e74810aad.svg)

The related CSV looks like this:

```csv
..&sol; (147 GB | 867 k),147934207228.000000,5.938393
..&sol; (147 GB | 867 k)/CPP&sol; (30 GB | 361 k),30802642261.000000,5.558565
..&sol; (147 GB | 867 k)/CPP&sol; (30 GB | 361 k)/Cataclysm-DDA&sol; (16 GB | 53 k),16554995652.000000,4.731307
..&sol; (147 GB | 867 k)/CPP&sol; (30 GB | 361 k)/Cataclysm-DDA&sol; (16 GB | 53 k)/.md (1.6 MB | 101),1588724.000000,2.004321
..&sol; (147 GB | 867 k)/CPP&sol; (30 GB | 361 k)/Cataclysm-DDA&sol; (16 GB | 53 k)/.sample (23 kB | 13),23442.000000,1.113943
...
```

Fixes #25 